### PR TITLE
File.Exists? -> File.Exist? per Ruby 2.2.0+

### DIFF
--- a/lib/RGSS/serialize.rb
+++ b/lib/RGSS/serialize.rb
@@ -172,10 +172,10 @@ module RGSS
     formatador = Formatador.new
     src_file = File.join(dirs[:data], src)
     dest_file = File.join(dirs[:yaml], dest)
-    raise "Missing #{src}" unless File.exists?(src_file)
+    raise "Missing #{src}" unless File.exist?(src_file)
 
     script_entries = load(:load_data_file, src_file)
-    check_time = !options[:force] && File.exists?(dest_file)
+    check_time = !options[:force] && File.exist?(dest_file)
     oldest_time = File.mtime(dest_file) if check_time
 
     file_map, script_index, script_code = Hash.new(-1), [], {}
@@ -194,7 +194,7 @@ module RGSS
         script_index.push([magic_number, script_name, actual_filename])
         full_filename = File.join(dirs[:script], actual_filename)
         script_code[full_filename] = code
-        check_time = false unless File.exists?(full_filename)
+        check_time = false unless File.exist?(full_filename)
         oldest_time = [File.mtime(full_filename), oldest_time].min if check_time
       else
         script_index.push([magic_number, script_name, nil])
@@ -215,8 +215,8 @@ module RGSS
     formatador = Formatador.new
     src_file = File.join(dirs[:yaml], src)
     dest_file = File.join(dirs[:data], dest)
-    raise "Missing #{src}" unless File.exists?(src_file)
-    check_time = !options[:force] && File.exists?(dest_file)
+    raise "Missing #{src}" unless File.exist?(src_file)
+    check_time = !options[:force] && File.exist?(dest_file)
     newest_time = File.mtime(src_file) if check_time
 
     index = load(:load_yaml_file, src_file)
@@ -226,7 +226,7 @@ module RGSS
       code = ''
       if filename
         full_filename = File.join(dirs[:script], filename)
-        raise "Missing script file #{filename}" unless File.exists?(full_filename)
+        raise "Missing script file #{filename}" unless File.exist?(full_filename)
         newest_time = [File.mtime(full_filename), newest_time].max if check_time
         code = load(:load_raw_file, full_filename)
       end
@@ -245,7 +245,7 @@ module RGSS
     fbase = File.basename(file, File.extname(file))
     return if (! options[:database].nil? ) and (options[:database].downcase != fbase.downcase)
     src_time = File.mtime(src_file)
-    if !options[:force] && File.exists?(dest_file) && (src_time - 1) < File.mtime(dest_file)
+    if !options[:force] && File.exist?(dest_file) && (src_time - 1) < File.mtime(dest_file)
       formatador.display_line("[yellow]Skipping #{file}[/]") if $VERBOSE
     else
       formatador.display_line("[green]Converting #{file} to #{dest_ext}[/]") if $VERBOSE
@@ -312,7 +312,7 @@ module RGSS
     }
 
     dirs.values.each do |d|
-      FileUtils.mkdir(d) unless File.exists?(d)
+      FileUtils.mkdir(d) unless File.exist?(d)
     end
 
     exts = {


### PR DESCRIPTION
#Spoiler: vernzimm<=newb

File.Exists? is deprecated as of Ruby 2.2.0. Spams console with warning message.
http://ruby-doc.org/core-2.2.0/File.html#exist-3F-method

I don't think this will break older versions as both previously existed at 1.9.3
http://ruby-doc.org/core-1.9.3/File.html#method-c-exist-3F