### PR TITLE
Compaitbility updates

### DIFF
--- a/bin/rvpacker
+++ b/bin/rvpacker
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
 
-require 'trollop'
+require 'optimist'
 require 'RGSS'
 
-opts = Trollop::options do
+opts = Optimist::options do
   opt :action, "Action to perform on project (unpack|pack)", :short => "a", :type => String
   opt :project, "RPG Maker Project directory", :short => "d", :type => String
   opt :force, "Update target even when source is older than target", :short => "f"
@@ -33,4 +33,3 @@ RGSS.serialize(projecttypes[opts[:project_type]],
                  :database => opts[:database]
                }
                )
-

--- a/rvpacker.gemspec
+++ b/rvpacker.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
-  spec.add_dependency "trollop"
+  spec.add_dependency "optimist"
   spec.add_dependency "psych", "2.0.0"
   spec.add_dependency "formatador"
+  spec.add_dependency "scanf"
 end


### PR DESCRIPTION
Update package requirements:
- add require scanf for Ruby 2.7.0 compatibility
- change require Trollop to require optimist per the gem's name change
- change all references to Trollop to reference Optimist instead